### PR TITLE
BUGFIX: RawGuzzleContext::compareArrays() looping

### DIFF
--- a/src/Behat/GuzzleExtension/Context/RawGuzzleContext.php
+++ b/src/Behat/GuzzleExtension/Context/RawGuzzleContext.php
@@ -242,10 +242,20 @@ class RawGuzzleContext implements GuzzleAwareContext
      */
     protected function compareArrays(array $input, array $control)
     {
-        foreach ($input as $field => $actual) {
-            if (isset($control[$field])) {
-                $this->compareValues($actual, $control[$field]);
+        foreach ($control as $field => $expected) {
+            if (!array_key_exists($field, $input)) {
+                throw new ClientErrorResponseException(
+                    sprintf(
+                        'Expected value %s is missing from array ' .
+                        'of actual values at position %s',
+                        is_array($expected) ?
+                        json_encode($expected) :
+                        $expected,
+                        $field
+                    )
+                );
             }
+            $this->compareValues($input[$field], $expected);
         }
     }
 


### PR DESCRIPTION
now loops over $control array not $input array so that it doesn't miss
out on asserting multiple values in array if less results actually get
returned than expected.
